### PR TITLE
Development

### DIFF
--- a/QRF/fn_callQRFEH.sqf
+++ b/QRF/fn_callQRFEH.sqf
@@ -1,6 +1,6 @@
 params [
   ["_group", grpNull, [grpNull, objNull]], // The group that EH will be attached and will "call" for a QRF
-  ["_delay", ["alertTime",15] call BIS_fnc_getParamValue, [0]], // The time that players will to neutralise the group's units before a QRF is called
+  ["_delay", ["alertTimeParam",15] call BIS_fnc_getParamValue, [0]], // The time that players will to neutralise the group's units before a QRF is called
   ["_pos", "HSO_QRFspawnPositions", ["", objNull, []], [2,3]], // The position of the spawned group will be spawned
   ["_QRFGroups", "HSO_QRFGroups", [""]], // The unit count of the QRF group
   ["_closestQRF", true, [false]], // If the QRF will spawn from the closest position available

--- a/QRF/fn_initQRFSystem.sqf
+++ b/QRF/fn_initQRFSystem.sqf
@@ -1,14 +1,30 @@
 if (!isServer) exitWith { "The function is executed only in the Server"; };
 
-addMissionEventHandler ["GroupCreated", {
-	params ["_group"];
+params [
+	["_delay", 10["alertTimeParam",15] call BIS_fnc_getParamValue, [0]],
+	["_pos", "HSO_QRFspawnPositions", ["", objNull, []], [2,3]],
+	["_QRFGroups", "HSO_QRFGroups", [""]],
+	["_closestQRF", true, [false]],
+	["_canCall", ["canCallQRFParam", 1] call BIS_fnc_getParamValue, [1]]
+];
+
+missionNamespace setVariable ["HSO_QRFGroupCreatedEHParams", _this, true];
+
+private _id = addMissionEventHandler ["GroupCreated", {
+	params ["_grp"];
 	private _handler = [] spawn {
 		sleep 10;
 		private _addEH = true;
 		{
 			if (isPlayer _x) exitWith { _addEH = false; };
-		} count (units _group);
+		} count (units _grp);
 
-		if (_addEH) then { [_group] call HSO_fnc_callQRFEH; };
+		if (_addEH) then {
+			private _params = missionNamespace getVariable ["HSO_QRFGroupCreatedEHParams", []];
+			_params = [_grp] append _params;
+			_params call HSO_fnc_callQRFEH;
+		};
 	};
 }];
+
+missionNamespace setVariable ["HSO_QRFGroupCreatedEHID", ["GroupCreated", _id], true];

--- a/QRF/fn_initQRFSystem.sqf
+++ b/QRF/fn_initQRFSystem.sqf
@@ -21,7 +21,7 @@ private _id = addMissionEventHandler ["GroupCreated", {
 
 		if (_addEH) then {
 			private _params = missionNamespace getVariable ["HSO_QRFGroupCreatedEHParams", []];
-			_params = [_grp] append _params;
+			_params = [_grp] + _params;
 			_params call HSO_fnc_callQRFEH;
 		};
 	};


### PR DESCRIPTION
Changed a default value to match the mission parameter class name that it was intented to set the default value for this specific param across all QRF System functions and it was wrong.

Added parameters to the fn_initQRFSystem.sqf so the HSO_fnc_initQRFSystem function has "tweakable" parameters to be passed to HSO_fnc_callQRFEH function for `allGroups`!